### PR TITLE
Added tenantId to the interfaces, added multi tenancy options

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -25,15 +25,18 @@ export interface BatchReadWriteRequest {
     // GET requests, only contains the URL of the resource
     fullUrl?: string;
     references?: Reference[];
+    tenantId?: string;
 }
 
 export interface BatchRequest {
     requests: BatchReadWriteRequest[];
     startTime: Date;
+    tenantId?: string;
 }
 export interface TransactionRequest {
     requests: BatchReadWriteRequest[];
     startTime: Date;
+    tenantId?: string;
 }
 
 // TODO all required?
@@ -44,6 +47,7 @@ export interface BatchReadWriteResponse {
     operation: TypeOperation | SystemOperation;
     resource: any;
     lastModified: string;
+    tenantId?: string;
 }
 
 export type BatchReadWriteErrorType = 'USER_ERROR' | 'SYSTEM_ERROR';

--- a/src/fhirConfig.ts
+++ b/src/fhirConfig.ts
@@ -11,6 +11,7 @@ import { History } from './history';
 import { Persistence } from './persistence';
 import { Search } from './search';
 import { Validator } from './validator';
+import { MultiTenancyOptions } from './multiTenancyOptions';
 
 /**
  * http://www.hl7.org/fhir/smart-app-launch/conformance/index.html#using-cs
@@ -156,6 +157,7 @@ export interface FhirConfig {
     productInfo: ProductInfo;
     auth: Auth;
     server: Server;
+    multiTenancyOptions: MultiTenancyOptions;
     profile: Profile;
     validators: Validator[];
 }

--- a/src/history.ts
+++ b/src/history.ts
@@ -9,6 +9,7 @@ export interface GlobalHistoryRequest {
     baseUrl: string; // server's URL
     queryParams?: any;
     searchFilters?: SearchFilter[];
+    tenantId?: string;
 }
 
 export interface TypeHistoryRequest extends GlobalHistoryRequest {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export * from './implementationGuides';
 export * from './persistence';
 export * from './resourceMeta';
 export * from './search';
+export * from './multiTenancyOptions';
 export * from './utilities';
 export * from './errors/InvalidResourceError';
 export * from './errors/ResourceNotFoundError';

--- a/src/multiTenancyOptions.ts
+++ b/src/multiTenancyOptions.ts
@@ -2,14 +2,14 @@ export interface MultiTenancyOptions {
     enabled: boolean;
 
     /**
-     * For url based multitenancy it allows to specifies a sub url part, like "tenant", "hospital" etc. or  Empty
+     * For url based multitenancy it allows to specify a sub url part, like "tenant", "hospital" etc. or  Empty
      * E.g.
      *  - Named url part: <fhir serverbase url>/<tenantUrlPart>/{tennatId}/resourceType/{resourceId}
      *  - Empty : <fhir serverbase url>/{tennatId}/resourceType/{resourceId}
      */
     tenantUrlPart?: string;
     /**
-     * array of tenant ids the logged in user has access to.
+     * The claim that has an array of tenant ids the logged in user has access to.
      * e.g. cognito user groups
      */
     tenantAccessTokenClaim?: string;

--- a/src/multiTenancyOptions.ts
+++ b/src/multiTenancyOptions.ts
@@ -1,0 +1,22 @@
+export interface MultiTenancyOptions {
+    enabled: boolean;
+
+    /**
+     * For url based multitenancy it allows to specifies a sub url part, like "tenant", "hospital" etc. or  Empty
+     * E.g.
+     *  - Named url part: <fhir serverbase url>/<tenantUrlPart>/{tennatId}/resourceType/{resourceId}
+     *  - Empty : <fhir serverbase url>/{tennatId}/resourceType/{resourceId}
+     */
+    tenantUrlPart?: string;
+    /**
+     * array of tenant ids the logged in user has access to.
+     * e.g. cognito user groups
+     */
+    tenantAccessTokenClaim?: string;
+    /**
+     * Due to cognito access token customisation limitation,
+     * the prefix helps to identify the tenant specific values in a claim.
+     * This allows to include access control on tenants next to user groups, like practitioners....
+     */
+    tenantAccessTokenClaimValuePrefix?: string;
+}

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -10,6 +10,7 @@ export interface CreateResourceRequest {
     resource: any;
     id?: string;
     ttlInSeconds?: number; // archive timestamp in Unix epoch time format in seconds
+    tenantId?: string;
 }
 
 export interface UpdateResourceRequest {
@@ -18,6 +19,7 @@ export interface UpdateResourceRequest {
     resource: any;
     vid?: string; // used in version aware update
     ttlInSeconds?: number; // archive timestamp in Unix epoch time format in seconds
+    tenantId?: string;
 }
 
 export interface PatchResourceRequest {
@@ -26,22 +28,26 @@ export interface PatchResourceRequest {
     resource: any;
     vid?: string; // used in version aware patch
     ttlInSeconds?: number; // archive timestamp in Unix epoch time format in seconds
+    tenantId?: string;
 }
 
 export interface ReadResourceRequest {
     id: string;
     resourceType: string;
+    tenantId?: string;
 }
 
 export interface vReadResourceRequest {
     id: string;
     vid: string;
     resourceType: string;
+    tenantId?: string;
 }
 
 export interface DeleteResourceRequest {
     id: string;
     resourceType: string;
+    tenantId?: string;
 }
 
 export interface ConditionalDeleteResourceRequest {

--- a/src/search.ts
+++ b/src/search.ts
@@ -14,6 +14,7 @@ export interface GlobalSearchRequest {
     baseUrl: string; // server's URL
     queryParams?: any;
     searchFilters?: SearchFilter[];
+    tenantUrl?: string; // optional tenant URL part + tenant id
 }
 
 export interface TypeSearchRequest extends GlobalSearchRequest {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -33,7 +33,7 @@ export function cleanAuthHeader(authorizationHeader?: string): string {
  * Returns everything before the query with the starting and ending '/' removed
  * ex: /Patient/?name=Joe -> Patient
  */
-function cleanUrlPath(urlPath: string): string {
+export function cleanUrlPath(urlPath: string): string {
     let path = urlPath.split('?')[0];
     if (path[0] === '/') {
         path = path.substr(1);


### PR DESCRIPTION
Description of changes:
Added MultiTenancyOptions interface, to store the multi tenancy configuration.
Added tenantId to several Request interfaces, in order to forward the tenantid to from routing to persistence and search.
Made cleanUrlPath available for routing repo, by exporting it.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.