### PR TITLE
Added the optional properties to MultiTenancyConfig

### DIFF
--- a/src/fhirConfig.ts
+++ b/src/fhirConfig.ts
@@ -175,6 +175,16 @@ export interface MultiTenancyConfig {
      * @example "nested.object.tenantId"
      */
     tenantIdClaimPath: string;
+    /**
+     * The prefix helps to identify the tenant specific values in a custom claim.
+     * @example "tenant:" would identify the tenant value "tenant:12345" in "cognito:groups" claim
+     */
+    tenantIdClaimValuePrefix?: string;
+    /**
+     * This optional option specifies a scope, which allows access to all tenants.
+     * This option is only applicable if useTenantSpecificUrl is enabled.
+     */
+    grantAccessAllTenantsScope?: string;
 }
 
 export interface FhirConfig {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Added the optional properties tenantIdClaimValuePrefix and grantAccessAllTenantsScope to MultiTenancyConfig interface

tenantIdClaimValuePrefix helps to identify tenant id values in a custom claim
grantAccessAllTenantsScope, contains a scope, which allows to access all tenants, this is required for machine to machine auth flows, which has to deal with multiple tenants
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.