### PR TITLE
feat: Update node version to 14

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - name: Install dependencies
         run: |
           yarn install

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.19",
-    "@types/node": "^12",
+    "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "eslint": "^7.32.0",
@@ -72,6 +72,6 @@
     "url": "git://github.com/awslabs/fhir-works-on-aws-interface.git"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   }
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes:

- Updates node, as AWS deprecated node 12 for AWS Lambda. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.